### PR TITLE
Use gps_speed to estimate speed

### DIFF
--- a/GEMstack/onboard/perception/state_estimation.py
+++ b/GEMstack/onboard/perception/state_estimation.py
@@ -35,6 +35,7 @@ class GNSSStateEstimator(Component):
                                     pitch=math.radians(inspva_msg.pitch),
                                     )
         self.status = inspva_msg.status
+        self.gps_speed = round(np.sqrt(inspva_msg.east_velocity**2 + inspva_msg.north_velocity**2), 2)
     
     def rate(self):
         return 10.0
@@ -67,8 +68,9 @@ class GNSSStateEstimator(Component):
         raw = readings.to_state(vehicle_pose_global)
 
         #filtering speed
-        filt_vel     = self.speed_filter(raw.v)
-        raw.v = filt_vel
+        # filt_vel     = self.speed_filter(raw.v)
+        # raw.v = filt_vel
+        raw.v = self.gps_speed
         return raw
         
 


### PR DESCRIPTION
Hi professor,

I found that the speed read from the state is not the vehicle's real velocity and it is always near 0. So I use the gps_speed instead, and it is good now.