### PR TITLE
S2024 estimation pixel-wise 3d coordinates in vehicle frame

### DIFF
--- a/GEMstack/onboard/perception/pixelwise_3D_lidar_coord_handler.py
+++ b/GEMstack/onboard/perception/pixelwise_3D_lidar_coord_handler.py
@@ -1,0 +1,146 @@
+import cv2
+import numpy as np
+
+
+class PixelWise3DLidarCoordHandler:
+    """ Provide pixelwise 3D lidar coordinate relative to the vehicle frame.
+        
+        Since lidar points are sparse after being projected onto the image frame, 
+        we have to do interpolation. This ensures that most image pixels have corresponding 3D coordinates.
+        
+        Algo overview pic:
+        https://github-production-user-asset-6210df.s3.amazonaws.com/22386566/327139371-20dfddd8-be83-418d-8c9a-d921a74895c5.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAVCODYLSA53PQK4ZA%2F20240501%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20240501T135905Z&X-Amz-Expires=300&X-Amz-Signature=b423d6fab8a5ece53df0ab70bf07d8c399c76c1513fa1123d8e2d6c3d61c4c36&X-Amz-SignedHeaders=host&actor_id=22386566&key_id=0&repo_id=732167109
+    """
+
+    def __init__(self,
+                 kernel_size=5,
+                 lidar2camera_fn="GEMstack/knowledge/calibration/gem_e4_lidar2oak.txt",
+                 intrinsic_fn="GEMstack/knowledge/calibration/gem_e4_intrinsic.txt",
+                 lidar2vehicle_fn="GEMstack/knowledge/calibration/gem_e4_lidar2vehicle.txt",
+                 xrange=(0, 20),
+                 yrange=(-10, 10),
+                 zrange=(-3, 1)) -> None:
+        """ 
+            Args:
+                kernel_size: kernel size for interpolation
+                lidar2camera_fn: filename of lidar to camera transformation matrix
+                intrinsic_fn: filename of camera intrinsic matrix
+                lidar2vehicle_fn: filename of lidar to vehicle rear_axle transformation matrix
+                xrange: predefined x range for computation. Range values are using lidar frame in meters.
+                yrange: predefined y range for computation. Range values are using lidar frame in meters.
+                zrange: predefined z range for computation. Range values are using lidar frame in meters.
+        """
+        self.T_lidar2camera = np.loadtxt(lidar2camera_fn)
+        self.T_lidar2vehicle = np.loadtxt(lidar2vehicle_fn)
+        self.intrinsic = np.loadtxt(intrinsic_fn)
+            
+        self.intrinsic = np.concatenate(
+            [self.intrinsic, np.zeros((3, 1))], axis=1)
+        
+        self.kernel_size = kernel_size
+
+        # For saving computation resource, only process lidar points within predefined range.
+        # These range values are using lidar frame.
+        self.xrange = xrange
+        self.yrange = yrange
+        self.zrange = zrange
+
+    def interpolate(self, coord_3d_map: np.ndarray):
+        def interpolate_single_channel(image, kernel):
+            """ helper function """
+            kernel = cv2.flip(kernel, flipCode=-1)
+            result = cv2.filter2D(
+                image, -1, kernel, borderType=cv2.BORDER_CONSTANT)
+
+            # Derive num_elements matrix
+            has_value = image > 0
+            has_value = has_value.astype(np.uint8)
+            num_elements_mat = cv2.filter2D(
+                has_value, -1, kernel, borderType=cv2.BORDER_CONSTANT)
+
+            # divide by num of elements correspond to that particular pixel
+            num_elements_mat[num_elements_mat == 0] = 1  # avoid divide by zero
+            final_result = result / num_elements_mat  # divide element-wise
+            return final_result
+
+        # do interpolation
+        channels = []
+        num_channels = coord_3d_map.shape[-1]
+        for i in range(num_channels):
+            channel = coord_3d_map[:, :, i]
+            kernel = np.ones(
+                (self.kernel_size, self.kernel_size), dtype=np.float32)
+            result = interpolate_single_channel(channel, kernel)
+            channels.append(result)
+
+        interpolate_3D_map = cv2.merge(channels)
+        return interpolate_3D_map
+
+    def filter_lidar_by_range(self, point_cloud: np.ndarray):
+        xmin, xmax = self.xrange
+        ymin, ymax = self.yrange
+        zmin, zmax = self.zrange
+        idxs = np.where((point_cloud[:, 0] > xmin) & (point_cloud[:, 0] < xmax) &
+                        (point_cloud[:, 1] > ymin) & (point_cloud[:, 1] < ymax) &
+                        (point_cloud[:, 2] > zmin) & (point_cloud[:, 2] < zmax))
+        return point_cloud[idxs]
+
+    def lidar_to_image(self, point_cloud_lidar: np.ndarray):
+
+        homo_point_cloud_lidar = np.hstack(
+            (point_cloud_lidar, np.ones((point_cloud_lidar.shape[0], 1))))  # (N, 4)
+        pointcloud_pixel = (self.intrinsic @ self.T_lidar2camera @
+                            (homo_point_cloud_lidar).T)  # (3, N)
+        pointcloud_pixel = pointcloud_pixel.T  # (N, 3)
+
+        # normalize
+        pointcloud_pixel[:, 0] /= pointcloud_pixel[:, 2]  # normalize
+        pointcloud_pixel[:, 1] /= pointcloud_pixel[:, 2]  # normalize
+        point_cloud_image = pointcloud_pixel[:, :2]  # (N, 2)
+        return point_cloud_image
+
+    def lidar_to_vehicle(self, point_cloud_lidar: np.ndarray):
+        ones = np.ones((point_cloud_lidar.shape[0], 1))
+        pcd_homogeneous = np.hstack((point_cloud_lidar, ones))  # (N, 4)
+        pointcloud_trans = np.dot(self.T_lidar2vehicle, pcd_homogeneous.T)  # (4, N)
+        pointcloud_trans = pointcloud_trans.T  # (N, 4)
+        point_cloud_image_world = pointcloud_trans[:, :3]  # (N, 3)
+        return point_cloud_image_world
+
+    def get3DCoord(self, image: np.ndarray, point_cloud: np.ndarray):
+        """ 
+            Return:
+                blend_3D_map: containing pixelwise 3D lidar coordinate in vehicle frame with
+                    dimensions (H x W x 3), where H and W correspond to the height and width of the image, respectively.
+        
+            Note:
+                if 3d coord of particular pixel == (0, 0, 0), it means we cannot get lidar 3D coord 
+                even after interpolation. Users should ignore that particular pixel for subsequent tasks.
+        """
+        filtered_point_cloud = self.filter_lidar_by_range(point_cloud)
+
+        point_cloud_3D = self.lidar_to_vehicle(filtered_point_cloud)
+
+        point_cloud_image = self.lidar_to_image(filtered_point_cloud)
+
+        # Keep only the lidar points whose projected coordinates lie within the boundary of images
+        height, width = image.shape[:2]
+        idxs = np.where((point_cloud_image[:, 0] > 0) & (point_cloud_image[:, 0] < width) &
+                        (point_cloud_image[:, 1] > 0) & (point_cloud_image[:, 1] < height))[0]
+
+        # initialize coord_3d_map
+        coord_3d_map = np.zeros(shape=(height, width, 3),
+                                dtype=point_cloud_3D.dtype)
+        for idx in idxs:
+            u, v = int(point_cloud_image[idx][0]), int(
+                point_cloud_image[idx][1])
+            coord_3d_map[v][u][:] = point_cloud_3D[idx]
+
+        # interpolate
+        interpolate_3D_map = self.interpolate(coord_3d_map)
+
+        # naive blending
+        mask = coord_3d_map > 0
+        blend_3D_map = coord_3d_map * mask + interpolate_3D_map * (1 - mask)
+        
+        return blend_3D_map

--- a/testing/test_get_pixel_3Dcoord.py
+++ b/testing/test_get_pixel_3Dcoord.py
@@ -1,0 +1,262 @@
+""" 
+    Usage for static frame:
+        $ python testing/test_get_pixel_3Dcoord.py -t frame
+        
+    Usage for rosbag:
+        $ python testing/test_get_pixel_3Dcoord.py -t rosbag 
+        $ rosbag play -l <rosbag_path>
+"""
+
+import sys
+import os
+import cv2
+import argparse
+import random
+import numpy as np
+from typing import Dict, Tuple, List
+import pathlib
+import os
+import cv2
+sys.path.append(os.getcwd())
+abs_path = os.path.abspath(os.path.dirname(__file__))
+
+from GEMstack.onboard.perception.pixelwise_3D_lidar_coord_handler import PixelWise3DLidarCoordHandler
+
+parser = argparse.ArgumentParser()
+
+parser.add_argument('--src_dir', '-s', type=str, default='./data/gt')
+parser.add_argument('--test_target', '-t', type=str, default='frame',
+                    choices=['frame',  'rosbag', 'test_conv'])
+parser.add_argument('--data_idx', '-i', type=int, default=3)
+parser.add_argument('--kernel_size', '-k', type=int, default=5)
+parser.add_argument('--vis_lidar', '-v', default=False, action='store_true')
+args = parser.parse_args()
+
+coord_3d_map = None
+mouse_x = None
+mouse_y = None
+
+def mouse_callback(event, x, y, flags, param):
+    global coord_3d_map
+    global mouse_x
+    global mouse_y
+    mouse_x = x
+    mouse_y = y
+    # if event == cv2.EVENT_MOUSEMOVE:
+    # Display pixel coordinates on the console
+    x_3d, y_3d, z_3d = coord_3d_map[y][x]
+    
+    print(
+        f"Pixel coordinates: x={x}, y={y} | 3D xyz coord: x={x_3d:.2f}, y={y_3d:.2f}, z={z_3d:.2f} (in meters)")
+
+
+if args.test_target == 'rosbag':
+    import sensor_msgs.point_cloud2 as pc2
+    from cv_bridge import CvBridge
+    import rospy
+    from sensor_msgs.msg import Image, PointCloud2
+
+    class TestNode:
+        def __init__(self, coord_3d_handler):
+            self.coord_3d_handler = coord_3d_handler
+            self.bridge = CvBridge()
+            rospy.Subscriber('/ouster/points', PointCloud2,
+                             self.lidar_callback)
+            rospy.Subscriber('/oak/rgb/image_raw', Image, self.camera_callback)
+            self.image = None
+            self.point_cloud = None
+
+        def camera_callback(self, image: Image):
+            self.image = image
+
+        def lidar_callback(self, point_cloud):
+            self.point_cloud = point_cloud
+
+        def can_run(self):
+            if self.image is None or self.point_cloud is None:
+                return False
+            return True
+
+        def run(self):
+            # convert data type
+            cv_image = self.bridge.imgmsg_to_cv2(self.image, "bgr8")
+            numpy_point_cloud = ros_PointCloud2_to_numpy(
+                self.point_cloud, want_rgb=False)
+
+            # get3DCoord
+            coord_3d_map = self.coord_3d_handler.get3DCoord(
+                cv_image, numpy_point_cloud)
+            
+            return coord_3d_map, cv_image.copy()
+
+
+def test_conv_2D():
+    # Define a sample image and kernel
+    image = np.array([
+        [10, 0, 0],
+        [0, 20, 0],
+        [0, 0, 30]
+    ], dtype=np.float32)
+
+    # Do convolution
+    kernel = np.array([
+        [1, 1],
+        [1, 1]
+    ], dtype=np.float32)
+    kernel = cv2.flip(kernel, flipCode=-1)
+    result = cv2.filter2D(image, -1, kernel, borderType=cv2.BORDER_CONSTANT)
+
+    # Derive num_elements matrix
+    has_value = image > 0
+    has_value = has_value.astype(np.uint8)
+    num_elements_mat = cv2.filter2D(
+        has_value, -1, kernel, borderType=cv2.BORDER_CONSTANT)
+
+    # divide by num of elements correspond to that particular pixel
+    num_elements_mat[num_elements_mat == 0] = 1  # avoid divide by zero
+    interpolation_result = result / num_elements_mat
+
+    # naive blending
+    mask = image > 0
+    blend_result = image * mask + interpolation_result * (1 - mask)
+    
+    print("Image:")
+    print(image)
+    print("\nKernel:")
+    print(kernel)
+    print("\nResult:")
+    print(result)
+    print("\nnum_elements_mat:")
+    print(num_elements_mat)
+    print("\n Interpolation Result:")
+    print(interpolation_result)
+    print("\n Blend Result:")
+    print(blend_result)
+
+
+def ros_PointCloud2_to_numpy(pc2_msg, want_rgb=False):
+    if pc2 is None:
+        raise ImportError("ROS is not installed")
+    # gen = pc2.read_points(pc2_msg, skip_nans=True)
+    gen = pc2.read_points(pc2_msg, skip_nans=True, field_names=['x', 'y', 'z'])
+
+    if want_rgb:
+        xyzpack = np.array(list(gen), dtype=np.float32)
+        if xyzpack.shape[1] != 4:
+            raise ValueError(
+                "PointCloud2 does not have points with color data.")
+        xyzrgb = np.empty((xyzpack.shape[0], 6))
+        xyzrgb[:, :3] = xyzpack[:, :3]
+        for i, x in enumerate(xyzpack):
+            rgb = x[3]
+            # cast float32 to int so that bitwise operations are possible
+            s = struct.pack('>f', rgb)
+            i = struct.unpack('>l', s)[0]
+            # you can get back the float value by the inverse operations
+            pack = ctypes.c_uint32(i).value
+            r = (pack & 0x00FF0000) >> 16
+            g = (pack & 0x0000FF00) >> 8
+            b = (pack & 0x000000FF)
+            # r,g,b values in the 0-255 range
+            xyzrgb[i, 3:] = (r, g, b)
+        return xyzrgb
+    else:
+        return np.array(list(gen), dtype=np.float32)[:, :3]
+
+from sklearn.cluster import DBSCAN
+def vis_dbscan(point_cloud_image, vis, epsilon = 0.1, min_samples = 5):
+    colors = []
+    colors += [(i, 0, 255) for i in range(100, 256, 25)]
+    colors += [(i, 255, 0) for i in range(100, 256, 25)]
+    colors += [(0, i, 255) for i in range(100, 256, 25)]
+    colors += [(255, i, 0) for i in range(100, 256, 25)]
+    colors += [(255, 0, i) for i in range(100, 256, 25)]
+    colors += [(0, 255, i) for i in range(100, 256, 25)]
+    seed = 19
+    random.seed(seed)
+    random.shuffle(colors)
+
+    # for epsilon in np.linspace(0.01, 0.2, 10):
+    # Perform DBSCAN clustering
+    dbscan = DBSCAN(eps=epsilon, min_samples=min_samples)
+    clusters = dbscan.fit_predict(filtered_point_cloud)
+
+    for proj_pt, cluster in zip(point_cloud_image, clusters):
+        color = colors[cluster % len(colors)]
+        radius = 1
+        center = int(proj_pt[0]), int(proj_pt[1])
+        cv2.circle(vis, center, radius, color, cv2.FILLED)
+
+
+if __name__ == '__main__':
+
+    if args.test_target == 'test_conv':
+        ### verify the correctness of opencv filter2D ###
+        test_conv_2D()
+
+    elif args.test_target == 'frame':
+        # load data
+        lidar_fn = os.path.join(args.src_dir, f'lidar{args.data_idx}.npz')
+        image_fn = os.path.join(args.src_dir, f'color{args.data_idx}.png')
+
+        point_cloud = np.load(lidar_fn)['arr_0']
+        image = cv2.imread(image_fn)
+
+        print('\nStart testing...')
+
+        # init handler
+        handler = PixelWise3DLidarCoordHandler(args.kernel_size)
+        coord_3d_map = handler.get3DCoord(image, point_cloud)
+        
+        if args.vis_lidar:
+            # get point_cloud_image
+            handler.filter_lidar_by_range(point_cloud)
+            filtered_point_cloud = handler.filter_lidar_by_range(point_cloud)
+            point_cloud_image = handler.lidar_to_image(filtered_point_cloud)
+
+            vis_dbscan(point_cloud_image, image)
+            
+        # check pixel 3D coords in interactive mode
+        cv2.namedWindow('Image')
+        cv2.setMouseCallback('Image', mouse_callback)
+        while True:
+            vis = image.copy()
+            cv2.circle(vis, center=(mouse_x, mouse_y), radius=5, color=(0, 0, 255), thickness=cv2.FILLED)
+            cv2.imshow('Image', vis)
+
+            # Break the loop if 'q' is pressed
+            if cv2.waitKey(1) & 0xFF == ord('q'):
+                break
+
+        cv2.destroyAllWindows()
+
+    elif args.test_target == 'rosbag':
+        rospy.init_node('test_node')
+        rate = rospy.Rate(30)  # Hz
+
+        # init class object
+        handler = PixelWise3DLidarCoordHandler(args.kernel_size)
+        test_node = TestNode(handler)
+
+        try:
+            print('\nStart testing...')
+            cv2.namedWindow('Image')
+            cv2.setMouseCallback('Image', mouse_callback)
+            
+            while not rospy.is_shutdown():
+                rate.sleep()
+                if not test_node.can_run():
+                    continue
+
+                coord_3d_map, image = test_node.run()
+
+                # check pixel 3D coords in interactive mode
+                cv2.circle(image, center=(mouse_x, mouse_y), radius=5, color=(0, 0, 255), thickness=cv2.FILLED)
+                cv2.imshow('Image', image)
+                
+                if cv2.waitKey(1) & 0xFF == ord("q"):
+                    exit(1)
+        except rospy.ROSInterruptException:
+            print('rospy node error.')
+
+    print('\nDone!')


### PR DESCRIPTION
Create a new object class `PixelWise3DLidarCoordHandler` to compute pixel-wise 3d coordinates in vehicle frame.

### What it does
1. Project lidar data points to the image frame by calibrated matrices.
2. Interpolation 
Since lidar points are sparse after being projected onto the image frame, interpolation is necessary. This ensures that most image pixels have corresponding 3D coordinates, as illustrated in the image below.  <br> <img width="599" alt="image" src="https://github.com/krishauser/GEMstack/assets/22386566/48d5bd74-4a79-4e91-a107-7db74f60dea6">

### Usage / Integration
```python
# Pseudo code for integration

from GEMstack.onboard.perception.pixelwise_3D_lidar_coord_handler import PixelWise3DLidarCoordHandler

image = getfromCallback() # get image from ros callback
point_cloud = getFromCallback() # get lidar point cloud from ros callback

handler = PixelWise3DLidarCoordHandler() # init handler

# coord3d_pixelwise shape == (image _height, image_width, 3)
coord3d_pixelwise = handler.get3DCoord(image, point_cloud, which_camera="front_center")

# do your own operations for 3d_coord

```

### Limitation
1. Cannot get 3D coordinate of the pixel if it is too close to vehicle. Because lidar data points does not cover these areas. 
2. If 3d coordinate of particular pixel == (0, 0, 0), it means we cannot get lidar 3D coord even after interpolation. Users should ignore that particular pixel for subsequent tasks.

### Play around testing script
```bash
# Test for static frame:
$ python testing/test_get_pixel_3Dcoord.py -t frame
        
# Test for rosbag:
$ python testing/test_get_pixel_3Dcoord.py -t rosbag 
$ rosbag play -l <rosbag_path>
```

### Demo
- [rosbag testing](https://www.youtube.com/watch?v=1LAHfjb6fe8)
- [static image testing](https://youtu.be/F2uVdz-1Onc)



