### PR TITLE
update on vio integration on Gemstack. Only files used for vio added …

### DIFF
--- a/GEMstack/onboard/interface/vioslam_reading.py
+++ b/GEMstack/onboard/interface/vioslam_reading.py
@@ -1,0 +1,8 @@
+from .gem import ObjectPose
+from .gem import dataclass
+
+#An object to package to the odometry message from VIO into a reading object
+@dataclass 
+class VioslamReading:
+    pose : ObjectPose
+    status : str

--- a/GEMstack/onboard/perception/state_estimation.py
+++ b/GEMstack/onboard/perception/state_estimation.py
@@ -17,6 +17,7 @@ from ...mathutils import transforms
 from ..interface.vioslam_reading import VioslamReading
 import rospy
 import numpy as np
+import subprocess
 
 class GNSSStateEstimator(Component):
     """Just looks at the GNSS reading to estimate the vehicle state"""
@@ -86,6 +87,8 @@ class VIOSlamEstimator(Component):
         self.status = None
 
         self.Vioslam_sub = rospy.Subscriber("/Odom", Odometry, self.callback_with_Vioslam_reading)
+        self.launch_file = "./launch/rgbdrtabmap.launch" # Specify the path to your rtabmap launch file
+        self.run_vio_rtabmap()
 
     def vio_slam_callback(self, reading : VioslamReading):
         self.Vioslam_pose = reading.pose
@@ -105,6 +108,12 @@ class VIOSlamEstimator(Component):
         [roll, pitch, yaw] = transforms.quaternion_to_euler(xw, yw, zw, w)
         start_pose = ObjectPose(ObjectFrameEnum.START,t = self.time(),x=x,y=y,z=z,yaw=yaw,roll=roll,pitch=pitch)
         self.vio_slam_callback(VioslamReading(start_pose,'ok'))
+    
+    def run_vio_rtabmap(self):
+        # Command to run roslaunch in a new terminal
+        command = f"x-terminal-emulator -e roslaunch {self.launch_file}"
+        # Execute the command
+        subprocess.Popen(command, shell=True)
 
     def rate(self):
         return 10.0
@@ -138,7 +147,6 @@ class VIOSlamEstimator(Component):
         #raw.v = filt_vel
         return raw
         
-
 
 class OmniscientStateEstimator(Component):
     """A state estimator used for the simulator which provides perfect state information"""

--- a/GEMstack/onboard/perception/state_estimation.py
+++ b/GEMstack/onboard/perception/state_estimation.py
@@ -11,6 +11,13 @@ from ..interface.gem import GEMInterface
 from ..component import Component
 from ..interface.gem_hardware import GNSSReading
 
+#necessary imports for processing Vio odometry information
+from nav_msgs.msg import Odometry
+from ...mathutils import transforms
+from ..interface.vioslam_reading import VioslamReading
+import rospy
+import numpy as np
+
 class GNSSStateEstimator(Component):
     """Just looks at the GNSS reading to estimate the vehicle state"""
     def __init__(self, vehicle_interface : GEMInterface):
@@ -59,6 +66,71 @@ class GNSSStateEstimator(Component):
 
         readings = self.vehicle_interface.get_reading()
         raw = readings.to_state(vehicle_pose_global)
+
+        #filtering speed
+        raw.v = self.gnss_speed
+        #filt_vel     = self.speed_filter(raw.v)
+        #raw.v = filt_vel
+        return raw
+    
+
+# class that updates the vehicle state object with poses from VIO odometry
+class VIOSlamEstimator(Component):
+    """Looks at the Vioslam reading to estimate the vehicle state"""
+    def __init__(self, vehicle_interface : GEMInterface):
+        self.vehicle_interface = vehicle_interface
+        self.Vioslam_pose = None
+        self.cam_location = settings.get('vehicle.calibration.front_camera.center_position')[:2]
+        self.P_c_cam = -1 * np.array(self.cam_location) #position of center of the vehicle relative to camera 
+        self.speed_filter  = OnlineLowPassFilter(1.2, 30, 4)
+        self.status = None
+
+        self.Vioslam_sub = rospy.Subscriber("/Odom", Odometry, self.callback_with_Vioslam_reading)
+
+    def vio_slam_callback(self, reading : VioslamReading):
+        self.Vioslam_pose = reading.pose
+        self.status = reading.status
+
+    # Get information from the visual odometry topic from rtabmap
+    def callback_with_Vioslam_reading(self, msg : Odometry):
+        # position
+        x=msg.pose.pose.position.x
+        y=msg.pose.pose.position.y
+        z=msg.pose.pose.position.z
+        # orientation quaternion
+        xw = msg.pose.pose.orientation.x
+        yw = msg.pose.pose.orientation.y
+        zw = msg.pose.pose.orientation.z
+        w = msg.pose.pose.orientation.w
+        [roll, pitch, yaw] = transforms.quaternion_to_euler(xw, yw, zw, w)
+        start_pose = ObjectPose(ObjectFrameEnum.START,t = self.time(),x=x,y=y,z=z,yaw=yaw,roll=roll,pitch=pitch)
+        self.vio_slam_callback(VioslamReading(start_pose,'ok'))
+
+    def rate(self):
+        return 10.0
+    
+    def state_outputs(self) -> List[str]:
+        return ['vehicle']
+
+    def healthy(self):
+        return self.Vioslam_pose is not None
+    
+    def rotation_mat(self, yaw):
+        return np.array([[math.cos(yaw), -math.sin(yaw)], [math.sin(yaw), math.cos(yaw)]])
+
+    def update(self) -> VehicleState:
+        if self.Vioslam_pose is None:
+            return
+        # reference point is located at the center of rear axle
+        center_x, center_y = np.array([self.Vioslam_pose.x, self.Vioslam_pose.y]) + \
+                        self.rotation_mat(self.Vioslam_pose.yaw) @ self.P_c_cam
+        print("VIO pose_start x, y, yaw = ", center_x, center_y, self.Vioslam_pose.yaw)
+        
+        self.Vioslam_pose.x=center_x
+        self.Vioslam_pose.y=center_y
+
+        readings = self.vehicle_interface.get_reading()
+        raw = readings.to_state(self.Vioslam_pose)
 
         #filtering speed
         raw.v = self.gnss_speed

--- a/launch/rgbdrtabmap.launch
+++ b/launch/rgbdrtabmap.launch
@@ -1,0 +1,57 @@
+<?xml version="1.0"?>
+
+<!-- Configuration file for launching rtabmap to perform visual odometry, build a map 
+of the scene and get localization information from through SLAM 
+
+Package in this file will be run when the main (entrypoint) is run with the variant ......-->
+
+<launch>
+    <arg name="name" default="oak" />
+
+
+    <!-- Choose visualization -->
+   <arg name="rviz" default="false" />
+   <arg name="rtabmap_viz" default="false" />
+
+   <param name="use_sim_time" type="bool" value="true"/>
+
+    <node type="rgbd_odometry" name="rgbd_odometry" pkg="rtabmap_odom">
+        <remap from="rgb/image" to="$(arg name)/rgb/image_raw"/>
+        <remap from="rgb/camera_info" to="$(arg name)/rgb/camera_info"/>
+        <remap from="depth/image" to="$(arg name)/stereo/image_raw"/>
+        <param name="frame_id" type="string" value="$(arg name)"/>
+        <remap from="imu"                    to="/oak/imu/data"/>
+
+        <rosparam param="subscribe_depth">True</rosparam>
+        <rosparam param="approx_sync">True</rosparam>
+        <rosparam param="approx_sync_max_interval">0.02</rosparam>
+        
+    </node>
+
+    <node type="rtabmap" name="rtabmap" pkg="rtabmap_slam" output="screen" args="--delete_db_on_start">
+        <remap from="rgb/image" to="$(arg name)/rgb/image_raw"/>
+        <remap from="rgb/camera_info" to="$(arg name)/rgb/camera_info"/>
+        <remap from="depth/image" to="$(arg name)/stereo/image_raw"/>
+        <rosparam param="Rtabmap/DetectionRate">3.5</rosparam>
+        <param name="frame_id" type="string" value="$(arg name)"/>
+
+
+    </node>
+
+    <!-- Visualisation RTAB-Map -->
+      <node if="$(arg rtabmap_viz)" pkg="rtabmap_viz" type="rtabmap_viz" name="rtabmap_viz" args="-d $(find rtabmap_demos)/launch/config/rgbd_gui.ini" output="screen">
+        <remap from="rgb/image" to="$(arg name)/rgb/image_raw"/>
+        <remap from="rgb/camera_info" to="$(arg name)/rgb/camera_info"/>
+        <remap from="depth/image" to="$(arg name)/stereo/image_raw"/>
+      </node>
+
+    <node if="$(arg rviz)" pkg="rviz" type="rviz" name="rviz" args="-d $(find rtabmap_demos)/launch/config/demo_rgbd_mapping.rviz">
+        <remap from="rgb/image" to="$(arg name)/rgb/image_raw"/>
+        <remap from="rgb/camera_info" to="$(arg name)/rgb/camera_info"/>
+        <remap from="depth/image" to="$(arg name)/stereo/image_raw"/>
+    </node>
+
+    <node name="" pkg="." type="main.py" output="screen" args="launch/vio_ped_avoidance.yaml">
+    </node>
+
+</launch>

--- a/main.py
+++ b/main.py
@@ -1,14 +1,5 @@
 from GEMstack.utils import settings,config
 import sys
-import subprocess
-
-def run_vio_rtabmap():
-    # Specify the path to your rtabmap launch file
-    launch_file = "./launch/rgbdrtabmap.launch"
-    # Command to run roslaunch in a new terminal
-    command = f"x-terminal-emulator -e roslaunch {launch_file}"
-    # Execute the command
-    subprocess.Popen(command, shell=True)
 
 if __name__=='__main__':
     launch_file = None
@@ -34,12 +25,6 @@ if __name__=='__main__':
         settings.set('run',run_config)
         if settings.get('run.name',None) is None:
             settings.set('run.name',launch_file)
-    
-    #if one runs main.py with argument '--estimator=vio' rtabmap will launch packages needed for vio
-    #make sure to specfiy "state_estimation : VIOSlamEstimator" field in your launch yaml file to use 
-    #Viostateesimator instead of GPS
-    if '--estimator=vio' in sys.argv:
-        run_vio_rtabmap()
 
     from GEMstack.onboard.execution import entrypoint
     entrypoint.main()

--- a/main.py
+++ b/main.py
@@ -1,5 +1,14 @@
 from GEMstack.utils import settings,config
 import sys
+import subprocess
+
+def run_vio_rtabmap():
+    # Specify the path to your rtabmap launch file
+    launch_file = "./launch/rgbdrtabmap.launch"
+    # Command to run roslaunch in a new terminal
+    command = f"x-terminal-emulator -e roslaunch {launch_file}"
+    # Execute the command
+    subprocess.Popen(command, shell=True)
 
 if __name__=='__main__':
     launch_file = None
@@ -25,6 +34,12 @@ if __name__=='__main__':
         settings.set('run',run_config)
         if settings.get('run.name',None) is None:
             settings.set('run.name',launch_file)
+    
+    #if one runs main.py with argument '--estimator=vio' rtabmap will launch packages needed for vio
+    #make sure to specfiy "state_estimation : VIOSlamEstimator" field in your launch yaml file to use 
+    #Viostateesimator instead of GPS
+    if '--estimator=vio' in sys.argv:
+        run_vio_rtabmap()
 
     from GEMstack.onboard.execution import entrypoint
     entrypoint.main()

--- a/setup/Vio_setup.md
+++ b/setup/Vio_setup.md
@@ -1,0 +1,7 @@
+To use vio instead of GPS for localization:
+
+    -install rtabmap on your system "sudo apt install ros--rtabmap-ros" (I already installed on gem04 vehicle)
+
+    -create your yaml launch file and for the field "drive.perception.state_estimation : VIOSlamEstimator " use VIOSlamEstimator component
+
+    -run command python3 main.py launch/<your_file>.yaml.You can configure the rgbdrtabmap.launch in 'launch/rgbdrtabmap.launch' file as needed to visualize the map creation in real time. Odometry information is published and the VIOSlamEstimator component updates the vehicle's VehicleState object where you can extract the ego pose.


### PR DESCRIPTION
…to branch s2024. 

To use vio instead of GPS for localization:

- install rtabmap on your system "sudo apt install ros-<distro>-rtabmap-ros" (I already installed on gem04 vehicle)
- create your yaml launch file and for the field "drive.perception.state_estimation : VIOSlamEstimator " use VIOSlamEstimator 
- run command python3 main.py --estimator=vio launch/vio_ped_avoidance.yaml, specifying the argument "--estimator=vio" to launch the rtabmap in another terminal. you can configure the rgbdrtabmap.launch file as needed to visualize the map creation in real time. Odometry information is published and the state_estimation.py updates the vehicle's vehicle state object where you can extract the pose. 

