### PR TITLE
[s2024_road] Adding code that trains the model used traffic sign and traffic light detection module

### DIFF
--- a/GEMstack/offboard/detection_learning/traffic_sign_and_light_model_train.py
+++ b/GEMstack/offboard/detection_learning/traffic_sign_and_light_model_train.py
@@ -1,0 +1,11 @@
+from ultralytics import YOLO
+
+model = YOLO("yolov8m.pt")
+model.train(data="data.yaml", epochs=50)
+metrics = model.val()
+
+metrics.box.map    # map50-95
+metrics.box.map50  # map50
+metrics.box.map75  # map75
+metrics.box.maps   # a list contains map50-95 of each category
+


### PR DESCRIPTION
This PR adds:

- traffic_sign_and_light_model_train.py to GEMstack/offboard/detection_learning/
- This is the code used to train the custom object detection model used in the traffic sign and traffic light detection module
- Code also runs the validation set