### PR TITLE
Update gem_e4_sensor_environment.yaml

### DIFF
--- a/GEMstack/knowledge/vehicle/gem_e4_sensor_environment.yaml
+++ b/GEMstack/knowledge/vehicle/gem_e4_sensor_environment.yaml
@@ -2,5 +2,5 @@ ros_topics:
   top_lidar: /ouster/points
   front_camera: /oak/rgb/image_raw
   front_depth: /oak/stereo/image_raw
-  gnss: /septentrio_gnss/insnavgeod
+  gnss: /novatel/inspva
   


### PR DESCRIPTION
The gnss message needs to be of type novatel/inspva as this is the newer sensor. The earlier name led to a conflict in message type of sensor_init.yaml and GEMstack