### PR TITLE
Added Gazebo Obstacle Detection

### DIFF
--- a/GEMstack/onboard/perception/obstacle_detection.py
+++ b/GEMstack/onboard/perception/obstacle_detection.py
@@ -1,0 +1,56 @@
+
+import threading
+import copy
+from typing import Dict
+from ..component import Component
+
+from ..interface.gem import GEMInterface
+from ...state.obstacle import ObstacleState
+
+class OmniscientObstacleDetector(Component):
+    """Obtains agent detections from a simulator"""
+    def __init__(self,vehicle_interface : GEMInterface):
+        self.vehicle_interface = vehicle_interface
+        self.obstacles = {}
+        self.lock = threading.Lock()
+
+    def rate(self):
+        return 15.0
+
+    def state_inputs(self):
+        return []
+
+    def state_outputs(self):
+        return ['obstacles']
+
+    def initialize(self):
+        self.vehicle_interface.subscribe_sensor('obstacle_detector',self.obstacle_callback, ObstacleState)
+
+    def obstacle_callback(self, name : str, obstacle : ObstacleState):
+        with self.lock:
+            self.obstacles[name] = obstacle
+
+    def update(self) -> Dict[str,ObstacleState]:
+        with self.lock:
+            return copy.deepcopy(self.obstacles)
+
+
+class GazeboObstacleDetector(OmniscientObstacleDetector):
+    """Obtains agent detections from the Gazebo simulator using model_states topic"""
+    def __init__(self, vehicle_interface : GEMInterface, tracked_obstacle_prefixes=None):
+        super().__init__(vehicle_interface)
+
+        # If specific model prefixes are provided, configure the interface to track them
+        if tracked_obstacle_prefixes is not None:
+            # Check if our interface has the tracked_model_prefixes attribute (is a GazeboInterface)
+            if hasattr(vehicle_interface, 'tracked_obstacle_prefixes'):
+                vehicle_interface.tracked_obstacle_prefixes = tracked_obstacle_prefixes
+                print(f"Configured GazeboConeDetector to track obstacles with prefixes: {tracked_obstacle_prefixes}")
+            else:
+                print("Warning: vehicle_interface doesn't support tracked_obstacle_prefixes configuration")
+
+    def initialize(self):
+        # Use the same agent_detector sensor as OmniscientAgentDetector
+        # The GazeboInterface implements this with model_states subscription
+        super().initialize()
+        print("GazeboConeDetector initialized and subscribed to model_states")

--- a/GEMstack/onboard/visualization/mpl_visualization.py
+++ b/GEMstack/onboard/visualization/mpl_visualization.py
@@ -97,6 +97,7 @@ class MPLVisualization(Component):
         # Print debugging info about the vehicle's position and frame
         if self.num_updates % 10 == 0:
             print(f"Vehicle position: ({state.vehicle.pose.x:.2f}, {state.vehicle.pose.y:.2f}), frame: {state.vehicle.pose.frame}")
+            print("Obstacle state:", state.obstacles)
         
         # Pedestrian metrics and position debugging
         ped_positions = []
@@ -245,6 +246,18 @@ class MPLVisualization(Component):
             self.axs[2].set_xlabel('Time (s)')
         except Exception as e:
             print(f"Error in pedestrian plot: {str(e)}")
+
+        try:
+            # ---- plot static obstacles in orange ----
+            for obs in state.obstacles.values():
+                x_obs, y_obs = obs.pose.x, obs.pose.y
+                self.axs[0].plot(x_obs, y_obs, 'o',
+                                markersize=8,
+                                markerfacecolor='orange',
+                                markeredgecolor='darkorange',
+                                label='_nolegend_')
+        except Exception as e:
+            print(f"Error plotting obstacles: {str(e)}")
 
         # Update canvas
         try:

--- a/GEMstack/state/__init__.py
+++ b/GEMstack/state/__init__.py
@@ -8,7 +8,7 @@ __all__ = ['PhysicalObject','ObjectPose','ObjectFrameEnum',
            'VehicleState',
            'Roadgraph',
            'Roadmap',
-           'Obstacle',
+           'Obstacle', 'ObstacleMaterialEnum','ObstacleStateEnum','ObstacleState',
            'Sign',
            'AgentState','AgentEnum','AgentActivityEnum',
            'SceneState',
@@ -23,7 +23,7 @@ from .physical_object import PhysicalObject, ObjectPose, ObjectFrameEnum
 from .trajectory import Path,Trajectory
 from .vehicle import VehicleState,VehicleGearEnum
 from .roadgraph import Roadgraph, RoadgraphLane, RoadgraphCurve, RoadgraphRegion, RoadgraphCurveEnum, RoadgraphLaneEnum, RoadgraphRegionEnum, RoadgraphSurfaceEnum, RoadgraphConnectionEnum
-from .obstacle import Obstacle, ObstacleMaterialEnum
+from .obstacle import Obstacle, ObstacleMaterialEnum, ObstacleStateEnum, ObstacleState
 from .sign import Sign, SignEnum, SignalLightEnum, SignState
 from .roadmap import Roadmap
 from .agent import AgentState, AgentEnum, AgentActivityEnum

--- a/GEMstack/state/obstacle.py
+++ b/GEMstack/state/obstacle.py
@@ -1,6 +1,7 @@
-from dataclasses import dataclass
+from __future__ import annotations
+from dataclasses import dataclass, replace
 from ..utils.serialization import register
-from .physical_object import PhysicalObject
+from .physical_object import ObjectFrameEnum,PhysicalObject #,convert_vector
 from enum import Enum
 
 class ObstacleMaterialEnum(Enum):
@@ -16,6 +17,14 @@ class ObstacleMaterialEnum(Enum):
     SMALL_ANIMAL = 9
     ROADKILL = 10
 
+class ObstacleStateEnum(Enum):
+    STOPPED = 0         # standing pedestrians, parked cars, etc. No need to predict motion.
+    MOVING = 1          # standard motion.  Predictions will be used here
+    FAST = 2            # indicates faster than usual motion
+    UNDETERMINED = 3    # unknown activity
+    STANDING = 4        # standing cone
+    LEFT = 5            # flipped cone facing left
+    RIGHT = 6           # flipped cone facing right
 
 @dataclass
 @register
@@ -23,3 +32,14 @@ class Obstacle(PhysicalObject):
     material : ObstacleMaterialEnum
     collidable : bool
 
+
+@dataclass
+@register
+class ObstacleState(PhysicalObject):
+    type: ObstacleMaterialEnum
+    activity: ObstacleStateEnum
+
+    def to_frame(self, frame: ObjectFrameEnum, current_pose=None, start_pose_abs=None) -> ObstacleState:
+        newpose = self.pose.to_frame(frame, current_pose, start_pose_abs)
+        # newvelocity = convert_vector(self.velocity, self.pose.frame, frame, current_pose, start_pose_abs)
+        return replace(self, pose=newpose) #, velocity=newvelocity)

--- a/launch/fixed_route.yaml
+++ b/launch/fixed_route.yaml
@@ -86,6 +86,10 @@ variants:
                         type: agent_detection.GazeboAgentDetector
                         args:
                             tracked_model_prefixes: ['pedestrian', 'car', 'bicycle']
+                    obstacle_detection:
+                        type: obstacle_detection.GazeboObstacleDetector
+                        args:
+                            tracked_obstacle_prefixes: ['cone']
             visualization: !include "mpl_visualization.yaml"
     log_ros:
         log:


### PR DESCRIPTION
Added Obstacle Detection from Gazebo Model State and corresponding visualization to mpl_visualization. Currently only handles cone, but can be extended by adding to ```tracked_obstacles_prefixes``` in the launch file

![inital_obstacle_placement](https://github.com/user-attachments/assets/2cdc86ee-eeb1-4965-8cc2-1633a0c3b5c9)
![obstacles_hit](https://github.com/user-attachments/assets/01860f4d-81df-4ccf-a0ef-3c6b5a19e610)
